### PR TITLE
return a plain ole string from scrape readoperation

### DIFF
--- a/common/src/main/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpoint.java
+++ b/common/src/main/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpoint.java
@@ -42,6 +42,7 @@ import org.springframework.http.ResponseEntity;
 public class PrometheusScrapeEndpoint {
 
   private final CollectorRegistry collectorRegistry;
+  private final String PROMETHEUS_CONTENT_TYPE = "text/plain;version=0.0.4";
 
   public PrometheusScrapeEndpoint(CollectorRegistry collectorRegistry) {
     this.collectorRegistry = collectorRegistry;
@@ -50,7 +51,7 @@ public class PrometheusScrapeEndpoint {
   // If you use produces = TextFormat.CONTENT_TYPE_004, for some reason the accept header is ignored
   // and a 406 is returned :/
   // So we will use ResponseEntity<String> and set the content type manually.
-  @ReadOperation
+  @ReadOperation(produces = PROMETHEUS_CONTENT_TYPE)
   public ResponseEntity<String> scrape() {
     try {
       Writer writer = new StringWriter();
@@ -62,7 +63,7 @@ public class PrometheusScrapeEndpoint {
       responseHeaders.set("Content-Type", TextFormat.CONTENT_TYPE_004);
       TextFormat.write004(writer, samples);
 
-      return ResponseEntity.ok(writer.toString());
+      return new ResponseEntity<String>(writer.toString(), responseHeaders, HttpStatus.OK);
     } catch (IOException ex) {
       // This actually never happens since StringWriter::write() doesn't throw any
       // IOException

--- a/common/src/main/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpoint.java
+++ b/common/src/main/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpoint.java
@@ -50,8 +50,8 @@ public class PrometheusScrapeEndpoint {
   // If you use produces = TextFormat.CONTENT_TYPE_004, for some reason the accept header is ignored
   // and a 406 is returned :/
   // So we will use ResponseEntity<String> and set the content type manually.
-  @ReadOperation()
-  public ResponseEntity<String> scrape() {
+  @ReadOperation
+  public String scrape() {
     try {
       Writer writer = new StringWriter();
       Enumeration<Collector.MetricFamilySamples> samples =
@@ -62,7 +62,7 @@ public class PrometheusScrapeEndpoint {
       responseHeaders.set("Content-Type", TextFormat.CONTENT_TYPE_004);
       TextFormat.write004(writer, samples);
 
-      return new ResponseEntity<>(writer.toString(), responseHeaders, HttpStatus.OK);
+      return writer.toString();
     } catch (IOException ex) {
       // This actually never happens since StringWriter::write() doesn't throw any
       // IOException

--- a/common/src/main/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpoint.java
+++ b/common/src/main/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpoint.java
@@ -51,7 +51,7 @@ public class PrometheusScrapeEndpoint {
   // and a 406 is returned :/
   // So we will use ResponseEntity<String> and set the content type manually.
   @ReadOperation
-  public String scrape() {
+  public ResponseEntity<String> scrape() {
     try {
       Writer writer = new StringWriter();
       Enumeration<Collector.MetricFamilySamples> samples =
@@ -62,7 +62,7 @@ public class PrometheusScrapeEndpoint {
       responseHeaders.set("Content-Type", TextFormat.CONTENT_TYPE_004);
       TextFormat.write004(writer, samples);
 
-      return writer.toString();
+      return ResponseEntity.ok(writer.toString());
     } catch (IOException ex) {
       // This actually never happens since StringWriter::write() doesn't throw any
       // IOException


### PR DESCRIPTION
Attempting to bypass 406 error thrown when telegraf scrapes endpoint